### PR TITLE
Disable submit button when chat input is empty

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -538,45 +538,51 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                               // const SizedBox(width: 8),
                               !shouldShowSendButton(provider)
                                   ? const SizedBox.shrink()
-                                  : GestureDetector(
-                                      onTap: provider.sendingMessage || provider.isUploadingFiles
-                                          ? null
-                                          : () {
-                                              HapticFeedback.mediumImpact(); // Changed from lightImpact to mediumImpact
-                                              String message = textController.text;
-                                              if (message.isEmpty) return;
-                                              if (connectivityProvider.isConnected) {
-                                                _sendMessageUtil(message);
-                                              } else {
-                                                ScaffoldMessenger.of(context).showSnackBar(
-                                                  const SnackBar(
-                                                    content:
-                                                        Text('Please check your internet connection and try again'),
-                                                    duration: Duration(seconds: 2),
-                                                  ),
-                                                );
-                                              }
-                                            },
-                                      child: Container(
-                                        height: 32,
-                                        width: 32,
-                                        decoration: BoxDecoration(
-                                          color: Colors.white,
-                                          borderRadius: BorderRadius.circular(22),
-                                          boxShadow: [
-                                            BoxShadow(
-                                              color: Colors.black.withOpacity(0.1),
-                                              blurRadius: 8,
-                                              offset: const Offset(0, 2),
+                                  : ValueListenableBuilder<TextEditingValue>(
+                                      valueListenable: textController,
+                                      builder: (context, value, child) {
+                                        bool isDisabled = provider.sendingMessage || 
+                                                        provider.isUploadingFiles || 
+                                                        value.text.trim().isEmpty;
+                                        
+                                        return GestureDetector(
+                                          onTap: isDisabled ? null : () {
+                                            HapticFeedback.mediumImpact();
+                                            String message = textController.text;
+                                            if (message.isEmpty) return;
+                                            if (connectivityProvider.isConnected) {
+                                              _sendMessageUtil(message);
+                                            } else {
+                                              ScaffoldMessenger.of(context).showSnackBar(
+                                                const SnackBar(
+                                                  content: Text('Please check your internet connection and try again'),
+                                                  duration: Duration(seconds: 2),
+                                                ),
+                                              );
+                                            }
+                                          },
+                                          child: Container(
+                                            height: 32,
+                                            width: 32,
+                                            decoration: BoxDecoration(
+                                              color: isDisabled ? Colors.grey[300] : Colors.white,
+                                              borderRadius: BorderRadius.circular(22),
+                                              boxShadow: isDisabled ? [] : [
+                                                BoxShadow(
+                                                  color: Colors.black.withOpacity(0.1),
+                                                  blurRadius: 8,
+                                                  offset: const Offset(0, 2),
+                                                ),
+                                              ],
                                             ),
-                                          ],
-                                        ),
-                                        child: const Icon(
-                                          FontAwesomeIcons.arrowUp,
-                                          color: Color(0xFF35343B),
-                                          size: 18,
-                                        ),
-                                      ),
+                                            child: Icon(
+                                              FontAwesomeIcons.arrowUp,
+                                              color: isDisabled ? Colors.grey[500] : const Color(0xFF35343B),
+                                              size: 18,
+                                            ),
+                                          ),
+                                        );
+                                      },
                                     ),
                             ],
                           ),


### PR DESCRIPTION
Implemented input validation in the chat interface to disable the submit button when the message field is empty or contains only whitespace. The button now appears grayed out in this state and becomes active only when valid text is entered, preventing users from sending blank messages and improving overall user experience.

https://github.com/user-attachments/assets/b0c0d98b-7933-48cc-af84-e56d3e1b4d0e

<img width="341" height="743" alt="Before" src="https://github.com/user-attachments/assets/9ba971e4-e8b3-468b-ba57-b528154a9cd9" />
<img width="339" height="730" alt="After" src="https://github.com/user-attachments/assets/40e13889-15c3-462b-afcb-2e8e7a7b86d9" />

Fixes #2