### PR TITLE
scroll to top when user taps the current page icon

### DIFF
--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -7,6 +7,7 @@ import 'package:omi/utils/ui_guidelines.dart';
 
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/providers/action_items_provider.dart';
+import 'package:omi/providers/home_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/services/apple_reminders_service.dart';
 import 'package:omi/utils/platform/platform_service.dart';
@@ -31,6 +32,12 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
+    // Register scroll-to-top callback
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<HomeProvider>().scrollToTopActionItems = _scrollToTop;
+      }
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       MixpanelManager().actionItemsPageOpened();
       final provider = Provider.of<ActionItemsProvider>(context, listen: false);
@@ -39,6 +46,16 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       }
       _checkExistingAppleReminders();
     });
+  }
+
+  void _scrollToTop() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeOut,
+      );
+    }
   }
 
   @override

--- a/app/lib/pages/apps/explore_install_page.dart
+++ b/app/lib/pages/apps/explore_install_page.dart
@@ -41,6 +41,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
   final ValueNotifier<App?> _selectedAppNotifier = ValueNotifier<App?>(null);
   late TextEditingController searchController;
   Debouncer debouncer = Debouncer(delay: const Duration(milliseconds: 500));
+  final ScrollController _scrollController = ScrollController();
 
   // Cache grouped apps to avoid recomputing on every rebuild
   Map<String, List<App>>? _cachedGroupedApps;
@@ -48,11 +49,27 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
 
   @override
   void initState() {
+    super.initState();
     searchController = TextEditingController();
+    // Register scroll-to-top callback
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<HomeProvider>().scrollToTopApps = _scrollToTop;
+      }
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<AddAppProvider>().init();
     });
-    super.initState();
+  }
+
+  void _scrollToTop() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeOut,
+      );
+    }
   }
 
   // Handle SelectAppNotification from child widgets
@@ -67,6 +84,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
   @override
   void dispose() {
     searchController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -307,6 +325,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
 
   Widget _buildShimmerAppsView() {
     return CustomScrollView(
+      controller: _scrollController,
       slivers: [
         const SliverToBoxAdapter(child: SizedBox(height: 8)),
         // Shimmer for Popular Apps
@@ -325,6 +344,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
       selector: (context, provider) => provider.filteredApps,
       builder: (context, filteredApps, child) {
         return CustomScrollView(
+          controller: _scrollController,
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 20)),
             if (filteredApps.isEmpty)
@@ -394,6 +414,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
         final mostDownloadedApps = allApps.take(20).toList(); // Get top 20 most downloaded
 
         return CustomScrollView(
+          controller: _scrollController,
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 8)),
 
@@ -482,6 +503,7 @@ class _ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticK
           ),
           builder: (context, state, child) {
             return CustomScrollView(
+              controller: _scrollController,
               slivers: [
                 const SliverToBoxAdapter(child: SizedBox(height: 12)),
                 SliverToBoxAdapter(

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -441,6 +441,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                               MixpanelManager().bottomNavigationTabClicked('Home');
                                               primaryFocus?.unfocus();
                                               if (home.selectedIndex == 0) {
+                                                home.triggerScrollToTop(0);
                                                 return;
                                               }
                                               home.setIndex(0);
@@ -473,6 +474,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                               MixpanelManager().bottomNavigationTabClicked('Action Items');
                                               primaryFocus?.unfocus();
                                               if (home.selectedIndex == 1) {
+                                                home.triggerScrollToTop(1);
                                                 return;
                                               }
                                               home.setIndex(1);
@@ -507,6 +509,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                               MixpanelManager().bottomNavigationTabClicked('Memories');
                                               primaryFocus?.unfocus();
                                               if (home.selectedIndex == 2) {
+                                                home.triggerScrollToTop(2);
                                                 return;
                                               }
                                               home.setIndex(2);
@@ -539,6 +542,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                               MixpanelManager().bottomNavigationTabClicked('Explore');
                                               primaryFocus?.unfocus();
                                               if (home.selectedIndex == 3) {
+                                                home.triggerScrollToTop(3);
                                                 return;
                                               }
                                               home.setIndex(3);

--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -156,6 +156,12 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
   @override
   void initState() {
     super.initState();
+    // Register scroll-to-top callback
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<HomeProvider>().scrollToTopMemories = _scrollToTop;
+      }
+    });
     // Set default filter based on current date
     final now = DateTime.now();
     final cutoffDate = DateTime(2025, 5, 31);
@@ -180,6 +186,16 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
         _showReviewSheet(context, unreviewedMemories, provider);
       }
     }).withPostFrameCallback();
+  }
+
+  void _scrollToTop() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeOut,
+      );
+    }
   }
 
   void _applyFilter(FilterOption option) {

--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -9,6 +9,10 @@ import 'package:omi/utils/analytics/analytics_manager.dart';
 class HomeProvider extends ChangeNotifier {
   int selectedIndex = 0;
   Function(int idx)? onSelectedIndexChanged;
+  VoidCallback? scrollToTopConversations;
+  VoidCallback? scrollToTopActionItems;
+  VoidCallback? scrollToTopMemories;
+  VoidCallback? scrollToTopApps;
   final FocusNode chatFieldFocusNode = FocusNode();
   final FocusNode appsSearchFieldFocusNode = FocusNode();
   final FocusNode convoSearchFieldFocusNode = FocusNode();
@@ -176,6 +180,23 @@ class HomeProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void triggerScrollToTop(int index) {
+    switch (index) {
+      case 0:
+        scrollToTopConversations?.call();
+        break;
+      case 1:
+        scrollToTopActionItems?.call();
+        break;
+      case 2:
+        scrollToTopMemories?.call();
+        break;
+      case 3:
+        scrollToTopApps?.call();
+        break;
+    }
+  }
+
   @override
   void dispose() {
     chatFieldFocusNode.removeListener(_onFocusChange);
@@ -187,6 +208,10 @@ class HomeProvider extends ChangeNotifier {
     appsSearchFieldFocusNode.dispose();
     convoSearchFieldFocusNode.dispose();
     onSelectedIndexChanged = null;
+    scrollToTopConversations = null;
+    scrollToTopActionItems = null;
+    scrollToTopMemories = null;
+    scrollToTopApps = null;
     super.dispose();
   }
 }


### PR DESCRIPTION
Implemented a feature that scrolls the current page to the top when the user taps its icon in the bottom navigation bar. This enhances usability by allowing quick access to the top of long pages without manual scrolling.

https://github.com/user-attachments/assets/e9519da0-0e4c-4698-b3b3-190f3d331eba


Fixes #11 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reselecting a bottom navigation tab now smoothly scrolls its page to the top via HomeProvider callbacks and page ScrollControllers.
> 
> - **UI/Navigation**:
>   - Bottom bar tab reselect triggers `home.triggerScrollToTop(index)` for tabs `Home(0)`, `Action Items(1)`, `Memories(2)`, `Apps(3)` in `app/lib/pages/home/page.dart`.
> - **Provider**:
>   - `HomeProvider` adds scroll-to-top callbacks: `scrollToTopConversations`, `scrollToTopActionItems`, `scrollToTopMemories`, `scrollToTopApps`, and `triggerScrollToTop(int)`; cleans up in `dispose()`.
> - **Pages**:
>   - `ConversationsPage`, `ActionItemsPage`, `MemoriesPage`, `ExploreInstallPage`:
>     - Add `ScrollController`, register `_scrollToTop()` with `HomeProvider` in `initState`, attach controller to primary `CustomScrollView`/`NestedScrollView`, and dispose controllers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6774e86cbc515ff4a823dff36840ed9cda21a4e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->